### PR TITLE
chore: add `types` entry to `export` map

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     ".": {
       "browser": "./dist/trace-mapping.umd.js",
       "require": "./dist/trace-mapping.umd.js",
-      "import": "./dist/trace-mapping.mjs"
+      "import": "./dist/trace-mapping.mjs",
+      "types": "./dist/types/trace-mapping.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/types/trace-mapping.d.ts",
       "browser": "./dist/trace-mapping.umd.js",
       "require": "./dist/trace-mapping.umd.js",
-      "import": "./dist/trace-mapping.mjs",
-      "types": "./dist/types/trace-mapping.d.ts"
+      "import": "./dist/trace-mapping.mjs"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
In one repo with `@jridgewell/trace-mapping` installed, I was playing with TS v4.7 Beta. Simply trying out `"module": "nodenext"` and `"moduleResolution": "node16"`.

Apparently presents of `exports` map in `package.json` overrides any other entry points (e.g. top level `types`, `typings` fields are ignored). While compiling with `"skipLibCheck": false`, `tsc` throws:

> 'Could not find a declaration file for module '@jridgewell/trace-mapping'. '/path/to/repo/node_modules/@jridgewell/trace-mapping/dist/trace-mapping.umd.js' implicitly has an 'any' type.'

Adding `types` to the `exports` map solves the issue. 