### PR TITLE
Fix presortedDecodedMap to only copy sourcemap fields

### DIFF
--- a/src/trace-mapping.ts
+++ b/src/trace-mapping.ts
@@ -145,10 +145,10 @@ export class TraceMap implements SourceMap {
   private declare _encoded: string | undefined;
 
   private declare _decoded: SourceMapSegment[][] | undefined;
-  private _decodedMemo = memoizedState();
+  private declare _decodedMemo: MemoState;
 
-  private _bySources: Source[] | undefined = undefined;
-  private _bySourceMemos: MemoState[] | undefined = undefined;
+  private declare _bySources: Source[] | undefined;
+  private declare _bySourceMemos: MemoState[] | undefined;
 
   constructor(map: SourceMapInput, mapUrl?: string | null) {
     const isString = typeof map === 'string';
@@ -176,6 +176,10 @@ export class TraceMap implements SourceMap {
       this._encoded = undefined;
       this._decoded = maybeSort(mappings, isString);
     }
+
+    this._decodedMemo = memoizedState();
+    this._bySources = undefined;
+    this._bySourceMemos = undefined;
   }
 
   static {

--- a/src/trace-mapping.ts
+++ b/src/trace-mapping.ts
@@ -311,37 +311,34 @@ export class TraceMap implements SourceMap {
     };
 
     presortedDecodedMap = (map, mapUrl) => {
-      const clone = Object.assign({}, map);
-      clone.mappings = [];
-      const tracer = new TraceMap(clone, mapUrl);
+      const tracer = new TraceMap(clone(map, []), mapUrl);
       tracer._decoded = map.mappings;
       return tracer;
     };
 
     decodedMap = (map) => {
-      return {
-        version: 3,
-        file: map.file,
-        names: map.names,
-        sourceRoot: map.sourceRoot,
-        sources: map.sources,
-        sourcesContent: map.sourcesContent,
-        mappings: decodedMappings(map),
-      };
+      return clone(map, decodedMappings(map));
     };
 
     encodedMap = (map) => {
-      return {
-        version: 3,
-        file: map.file,
-        names: map.names,
-        sourceRoot: map.sourceRoot,
-        sources: map.sources,
-        sourcesContent: map.sourcesContent,
-        mappings: encodedMappings(map),
-      };
+      return clone(map, encodedMappings(map));
     };
   }
+}
+
+function clone<T extends string | readonly SourceMapSegment[][]>(
+  map: TraceMap | DecodedSourceMap | EncodedSourceMap,
+  mappings: T,
+): T extends string ? EncodedSourceMap : DecodedSourceMap {
+  return {
+    version: map.version,
+    file: map.file,
+    names: map.names,
+    sourceRoot: map.sourceRoot,
+    sources: map.sources,
+    sourcesContent: map.sourcesContent,
+    mappings,
+  } as any;
 }
 
 function OMapping(

--- a/test/trace-mapping.test.ts
+++ b/test/trace-mapping.test.ts
@@ -397,5 +397,16 @@ describe('TraceMap', () => {
       const tracer = presortedDecodedMap(reversedDecoded);
       t.deepEqual(decodedMappings(tracer), mappings);
     });
+
+    test('ignores non-sourcemap fields from output', (t) => {
+      // `map` will contain a `_encoded` field equal to the encoded map's, a _decoded equal to [],
+      // and a _decodedMemo field. This fooled the duck-type early return detection, and preserved
+      // invalid values on the presorted tracer.
+      // https://github.com/facebook/jest/issues/12998#issuecomment-1212426850
+      const map = Object.assign({}, new TraceMap(encodedMap), { mappings: [] });
+      const tracer = presortedDecodedMap(map);
+
+      t.is(encodedMappings(tracer), '');
+    });
   });
 });


### PR DESCRIPTION
Before, the presorted map would incorrectly copy over fields such as `_decodedMemo`, which fooled the duck-typing early return optimization. That would allow invalid `_encoded` state to be preserved, even if I explicitly set the map's `mappings` to a decoded segments array.

Fixes https://github.com/facebook/jest/issues/12998