### PR TITLE
Be more permissive with readonly input types

### DIFF
--- a/src/any-map.ts
+++ b/src/any-map.ts
@@ -12,6 +12,7 @@ import type {
   SectionedSourceMap,
   DecodedSourceMap,
   SectionedSourceMapInput,
+  Ro,
 } from './types';
 import type { SourceMapSegment } from './sourcemap-segment';
 
@@ -46,7 +47,7 @@ export const AnyMap: AnyMap = function (map, mapUrl) {
 } as AnyMap;
 
 function recurse(
-  input: SectionedSourceMap,
+  input: Ro<SectionedSourceMap>,
   mapUrl: string | null | undefined,
   mappings: SourceMapSegment[][],
   sources: string[],
@@ -90,7 +91,7 @@ function recurse(
 }
 
 function addSection(
-  input: Section['map'],
+  input: Ro<Section['map']>,
   mapUrl: string | null | undefined,
   mappings: SourceMapSegment[][],
   sources: string[],

--- a/src/trace-mapping.ts
+++ b/src/trace-mapping.ts
@@ -159,7 +159,7 @@ export class TraceMap implements SourceMap {
 
     if (!isString && (map as unknown as { _decodedMemo: any })._decodedMemo) return map as TraceMap;
 
-    const parsed = (isString ? JSON.parse(map) : map) as Exclude<SourceMapInput, string | TraceMap>;
+    const parsed = (isString ? JSON.parse(map) : map) as DecodedSourceMap | EncodedSourceMap;
 
     const { version, file, names, sourceRoot, sources, sourcesContent } = parsed;
     this.version = version;

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,14 +57,6 @@ export type InvalidGeneratedMapping = {
 
 export type Bias = typeof GREATEST_LOWER_BOUND | typeof LEAST_UPPER_BOUND;
 
-type Ro<T> = T extends Array<infer V>
-  ? V[] | Readonly<V[]> | RoArray<V> | Readonly<RoArray<V>>
-  : T extends object
-  ? T | Readonly<T> | RoObject<T> | Readonly<RoObject<T>>
-  : T;
-type RoArray<T> = Ro<T>[];
-type RoObject<T> = { [K in keyof T]: T[K] | Ro<T[K]> };
-
 export type SourceMapInput = string | Ro<EncodedSourceMap> | Ro<DecodedSourceMap> | TraceMap;
 
 export type SectionedSourceMapInput = SourceMapInput | Ro<SectionedSourceMap>;
@@ -99,3 +91,11 @@ export abstract class SourceMap {
   declare sourcesContent: SourceMapV3['sourcesContent'];
   declare resolvedSources: SourceMapV3['sources'];
 }
+
+export type Ro<T> = T extends Array<infer V>
+  ? V[] | Readonly<V[]> | RoArray<V> | Readonly<RoArray<V>>
+  : T extends object
+  ? T | Readonly<T> | RoObject<T> | Readonly<RoObject<T>>
+  : T;
+type RoArray<T> = Ro<T>[];
+type RoObject<T> = { [K in keyof T]: T[K] | Ro<T[K]> };

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,8 +57,17 @@ export type InvalidGeneratedMapping = {
 
 export type Bias = typeof GREATEST_LOWER_BOUND | typeof LEAST_UPPER_BOUND;
 
-export type SourceMapInput = string | EncodedSourceMap | DecodedSourceMap | TraceMap;
-export type SectionedSourceMapInput = SourceMapInput | SectionedSourceMap;
+type Ro<T> = T extends Array<infer V>
+  ? V[] | Readonly<V[]> | RoArray<V> | Readonly<RoArray<V>>
+  : T extends object
+  ? T | Readonly<T> | RoObject<T> | Readonly<RoObject<T>>
+  : T;
+type RoArray<T> = Ro<T>[];
+type RoObject<T> = { [K in keyof T]: T[K] | Ro<T[K]> };
+
+export type SourceMapInput = string | Ro<EncodedSourceMap> | Ro<DecodedSourceMap> | TraceMap;
+
+export type SectionedSourceMapInput = SourceMapInput | Ro<SectionedSourceMap>;
 
 export type Needle = { line: number; column: number; bias?: Bias };
 export type SourceNeedle = { source: string; line: number; column: number; bias?: Bias };

--- a/test/any-map.test.ts
+++ b/test/any-map.test.ts
@@ -3,7 +3,7 @@
 import { test, describe } from './setup';
 import { AnyMap, encodedMappings, decodedMappings } from '../src/trace-mapping';
 
-import type { SectionedSourceMap } from '../src/trace-mapping';
+import type { SectionedSourceMap, SourceMapSegment } from '../src/trace-mapping';
 
 describe('AnyMap', () => {
   const map: SectionedSourceMap = {
@@ -124,6 +124,23 @@ describe('AnyMap', () => {
         'thirdsource',
         'fourthsource',
       ]);
+    });
+  });
+
+  describe('typescript readonly type', () => {
+    test('decoded source map', (t) => {
+      // This is a TS lint test, not a real one.
+      t.pass();
+
+      const decodedMap = {
+        version: 3 as const,
+        sources: ['input.js'] as readonly string[],
+        names: [] as readonly string[],
+        mappings: [] as readonly SourceMapSegment[][],
+        sourcesContent: [] as readonly string[],
+      };
+
+      new AnyMap(decodedMap);
     });
   });
 });

--- a/test/trace-mapping.test.ts
+++ b/test/trace-mapping.test.ts
@@ -24,6 +24,7 @@ import type {
   EncodedSourceMap,
   DecodedSourceMap,
   EachMapping,
+  SourceMapSegment,
 } from '../src/trace-mapping';
 
 describe('TraceMap', () => {
@@ -460,6 +461,23 @@ describe('TraceMap', () => {
       const tracer = presortedDecodedMap(map);
 
       t.is(encodedMappings(tracer), '');
+    });
+  });
+
+  describe('typescript readonly type', () => {
+    test('decoded source map', (t) => {
+      // This is a TS lint test, not a real one.
+      t.pass();
+
+      const decodedMap = {
+        version: 3 as const,
+        sources: ['input.js'] as readonly string[],
+        names: [] as readonly string[],
+        mappings: [] as readonly SourceMapSegment[][],
+        sourcesContent: [] as readonly string[],
+      };
+
+      new TraceMap(decodedMap);
     });
   });
 });


### PR DESCRIPTION
`gen-mapping`'s `toDecodedMap` returns a map object with a [`readonly SourceMapSegment[][]`](https://github.com/jridgewell/gen-mapping/blob/9ff6f25fa9bd12eeb9d265a17dd7631133669fdc/src/types.ts#L16-L18). This is because the `GenMapping` is returning its live reference to the internal decoded mappings, and I didn't want someone to modify the array after receiving it.

This change makes the input types completely permissive with fields that are mutable/readonly, recursively.

Fixes https://github.com/jridgewell/trace-mapping/issues/21.