### PR TITLE
fix: add "types" field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "main": "dist/trace-mapping.umd.js",
   "module": "dist/trace-mapping.mjs",
   "typings": "dist/types/trace-mapping.d.ts",
+  "types": "dist/types/trace-mapping.d.ts",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   ],
   "main": "dist/trace-mapping.umd.js",
   "module": "dist/trace-mapping.mjs",
-  "typings": "dist/types/trace-mapping.d.ts",
   "types": "dist/types/trace-mapping.d.ts",
   "files": [
     "dist"


### PR DESCRIPTION
So that older versions of typescript without support for exports map are able to resolve types correctly.

see https://github.com/sveltejs/svelte/pull/8362 for an example where it failed