### PR TITLE
Fix handling of sectioned source maps missing 'names' array

### DIFF
--- a/src/trace-mapping.ts
+++ b/src/trace-mapping.ts
@@ -163,7 +163,7 @@ export class TraceMap implements SourceMap {
     const { version, file, names, sourceRoot, sources, sourcesContent } = parsed;
     this.version = version;
     this.file = file;
-    this.names = names;
+    this.names = names || [];
     this.sourceRoot = sourceRoot;
     this.sources = sources;
     this.sourcesContent = sourcesContent;

--- a/test/any-map.test.ts
+++ b/test/any-map.test.ts
@@ -58,7 +58,6 @@ describe('AnyMap', () => {
               offset: { line: 0, column: 1 },
               map: {
                 version: 3,
-                names: [],
                 sources: ['fourth.js'],
                 sourcesContent: ['fourthsource'],
                 mappings: 'AAAA',


### PR DESCRIPTION
Even though the `names` array is seen as required, normalize it to an empty array if omitted

Currently, trace-mapping will throw with an exception `"Cannot read properties of undefined (reading 'length')"` in case no 'names' array is provided.